### PR TITLE
Wrong OTP handling and resend OTP option

### DIFF
--- a/src/pages/login/login.html
+++ b/src/pages/login/login.html
@@ -79,6 +79,14 @@
   <ion-row class="row-style" style="margin-top: 20px;"><ion-input placeholder="Enter OTP here" [(ngModel)]="otpnum"></ion-input></ion-row>
   <button ion-button ion-button block round outline color="light" style="margin-top: 20px;" (click)="otpFn()">{{"Submit OTP"|translate}}</button>
   <button ion-button ion-button block round outline color="light" style="margin-top: 20px;" (click)="backToLogin()">{{"Cancel"|translate}}</button>
+  <ion-row style="margin-top: 20px;">
+    <ion-col col-9>
+      <button ion-button [disabled]="timer!=0" (click)="signInPhone()" round outline color="light">Resend OTP</button>
+    </ion-col>
+    <ion-col col-3 style="color: white; margin-top: 10px; text-align: center;" *ngIf="timer!=0">
+      <span>Retry in {{ timer }}s</span>
+    </ion-col>
+  </ion-row>
 </div>
 
 <div *ngIf="signup==1">

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -53,7 +53,6 @@ export class LoginPage {
     //this.loadDropDowns();
     //this.getInfo();
     this.country_code = "95";
-
     const loading = this.loadingCtrl.create({
       content: `
         <div class="custom-spinner-container">
@@ -139,6 +138,16 @@ export class LoginPage {
           })
           .present();
       });
+  }
+  
+  timer=30;
+  startTimer(){
+    this.zone.run(()=>{
+      let interval = setInterval(()=>{
+        this.timer--;
+        if(this.timer==0) clearInterval(interval);
+      }, 1000);
+    });
   }
 
   language;
@@ -571,6 +580,27 @@ export class LoginPage {
             duration: 2000,
           })
           .present();
+        let a = this.alertCtrl.create({
+          title: "Incorrect OTP",
+          subTitle: "OTP entered is incorrect. Request new OTP or retry",
+          buttons: [
+            {
+              text: "Retry",
+              role: "cancel",
+              handler: ()=>{
+                this.otpnum="";
+              }
+            },
+            {
+              text: "New OTP",
+              handler: () => { 
+                this.otpmode = 0;
+                this.otpnum = "";
+              }
+            },
+          ],
+        });
+        a.present();
       })
       .finally(() => {
         if (flag == 1) {
@@ -618,6 +648,8 @@ export class LoginPage {
         .then(confirmationResult => {
           this.otpmode = 1;
           this.confirmres = confirmationResult;
+          this.timer = 30;
+          this.startTimer();
           // SMS sent. Prompt user to type the code from the message, then sign the
           // user in with confirmationResult.confirm(code).
 


### PR DESCRIPTION
1) Wrong OTP handler
 a) Redirects back to enter number page
 b) Retry entering OTP
Translation needed for the alert that pops up on entering the wrong OTP
2) Request new OTP after 30 seconds (can be changed to a different time interval, change required in 2 positions)